### PR TITLE
Changed TOF distance[] to unsigned

### DIFF
--- a/2025/FeatherCAN/FeatherCAN.ino
+++ b/2025/FeatherCAN/FeatherCAN.ino
@@ -130,7 +130,7 @@ extern float angle_f;
 
 uint32_t proximity[COLOR_SENSOR_MAX];
 
-int16_t distance[TOF_SENSOR_MAX];
+uint16_t distance[TOF_SENSOR_MAX];
 
 // were we able to initialize the sensor?
 int proximity_sensor_exists[COLOR_SENSOR_MAX];

--- a/2025/FeatherCAN/PackMessage.cpp
+++ b/2025/FeatherCAN/PackMessage.cpp
@@ -76,7 +76,7 @@ void packClimberMsg(float angle_f, uint32_t prox[])
 
 
 // pack Belly pan TOF sensor data into CAN message
-void packBellypanTOFMsg(int16_t tofDistance[])
+void packBellypanTOFMsg(uint16_t tofDistance[])
 {
   data[0] = (tofDistance[0] >> 8) & 0x00ff;
   data[1] = tofDistance[0] & 0x00ff;

--- a/2025/FeatherCAN/PackMessage.h
+++ b/2025/FeatherCAN/PackMessage.h
@@ -16,7 +16,7 @@ void packAlgaeMsg(float angle_f, uint16_t tofDistance);
 void packClimberMsg(float angle_f, uint32_t prox[]);
 
 // pack Belly pan TOF sensor data into CAN message
-void packBellypanTOFMsg(int16_t tofDistance[]);
+void packBellypanTOFMsg(uint16_t tofDistance[]);
 
 
 // pack angle data into CAN message


### PR DESCRIPTION
Changed TOF distance[] to unsigned, which is what is should have been.
Now 0xFFFF values for when it can't get a reading (no reflection I think), correctly looks like a large distance, and the debug LED correctly indicates whether Algae is close enough or there is no reflection.